### PR TITLE
Update vLLM deployment doc to use Docker image for vLLM v0.8.3

### DIFF
--- a/docs/vllm_deployment_guild.md
+++ b/docs/vllm_deployment_guild.md
@@ -74,13 +74,13 @@ To ensure consistency and stability of the deployment environment, we recommend 
 
 1. Get the container image:
 ```bash
-docker pull vllm/vllm-openai:v0.7.1
+docker pull vllm/vllm-openai:v0.8.3
 ```
 
 2. Run the container:
 ```bash
 # Set environment variables
-IMAGE=vllm/vllm-openai:v0.7.1
+IMAGE=vllm/vllm-openai:v0.8.3
 MODEL_DIR=<model storage path>
 CODE_DIR=<code path>
 NAME=MiniMaxImage

--- a/docs/vllm_deployment_guild_cn.md
+++ b/docs/vllm_deployment_guild_cn.md
@@ -72,13 +72,13 @@ git clone https://huggingface.co/MiniMaxAI/MiniMax-VL-01
 
 1. 获取容器镜像：
 ```bash
-docker pull vllm/vllm-openai:v0.7.1
+docker pull vllm/vllm-openai:v0.8.3
 ```
 
 2. 运行容器：
 ```bash
 # 设置环境变量
-IMAGE=vllm/vllm-openai:v0.7.1
+IMAGE=vllm/vllm-openai:v0.8.3
 MODEL_DIR=<模型存放路径>
 CODE_DIR=<代码路径>
 NAME=MiniMaxImage


### PR DESCRIPTION
The documentation previously referenced a development version of the vLLM Docker image because v0.8.3 had not yet been officially released. Now that v0.8.3 is available, the doc has been updated to use the official v0.8.3 Docker image to ensure reproducibility and consistency.